### PR TITLE
Pending bn update shrooooms

### DIFF
--- a/Dorf_Life/harvest.json
+++ b/Dorf_Life/harvest.json
@@ -2,26 +2,26 @@
   {
     "id": "helmet_plump_harv",
     "type": "harvest",
-    "entries": [ { "drop": "caveyot_helmet_plump", "base_num": [ 2, 6 ] }, { "drop": "withered", "base_num": [ 0, 1 ] } ]
+    "entries": [ { "drop": "caveyot_helmet_plump", "base_num": [ 1, 2 ] }, { "drop": "withered", "base_num": [ 0, 1 ] } ]
   },
   {
     "id": "pod_sweet_harv",
     "type": "harvest",
-    "entries": [ { "drop": "caveyot_pod_sweet", "base_num": [ 4, 8 ] }, { "drop": "withered", "base_num": [ 1, 3 ] } ]
+    "entries": [ { "drop": "caveyot_pod_sweet", "base_num": [ 1, 3 ] }, { "drop": "withered", "base_num": [ 1, 3 ] } ]
   },
   {
     "id": "wheat_cave_harv",
     "type": "harvest",
-    "entries": [ { "drop": "caveyot_wheat_cave", "base_num": [ 4, 8 ] }, { "drop": "straw_pile", "base_num": [ 1, 3 ] } ]
+    "entries": [ { "drop": "caveyot_wheat_cave", "base_num": [ 1, 3 ] }, { "drop": "straw_pile", "base_num": [ 1, 3 ] } ]
   },
   {
     "id": "tail_pig_harv",
     "type": "harvest",
-    "entries": [ { "drop": "caveyot_tails_pig", "base_num": [ 4, 8 ] }, { "drop": "plant_fibre", "base_num": [ 1, 4 ] } ]
+    "entries": [ { "drop": "caveyot_tails_pig", "base_num": [ 1, 3 ] }, { "drop": "plant_fibre", "base_num": [ 1, 4 ] } ]
   },
   {
     "id": "bush_quarry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "caveyot_bush_quarry", "base_num": [ 4, 8 ] }, { "drop": "stick", "base_num": [ 2, 3 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] }, { "drop": "log", "base_num": [ 0, 2 ] } ]
+    "entries": [ { "drop": "caveyot_bush_quarry", "base_num": [ 1, 3 ] }, { "drop": "stick", "base_num": [ 2, 3 ] }, { "drop": "stick_long", "base_num": [ 1, 2 ] }, { "drop": "log", "base_num": [ 0, 2 ] } ]
   }
 ]

--- a/Dorf_Life/items.json
+++ b/Dorf_Life/items.json
@@ -16,7 +16,9 @@
     "material": "mushroom",
     "volume": "250 ml",
     "flags": [ "EATEN_HOT", "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE" ],
-    "fun": -1
+    "fun": -1,
+    "charges": 4,
+    "vitamins": [ [ "vitC", 4 ], [ "iron", 7 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -48,7 +50,8 @@
     "description": "A bright red bulb resembling an onion, far more scarlet than the purple of any earthly red onion.  Though it gives off a sweet aroma, its layers are tough and difficult to peel, making it inedible as-is.",
     "price": "150 cent",
     "material": [ "mushroom", "wood" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "charges": 4
   },
   {
     "type": "COMESTIBLE",
@@ -61,7 +64,8 @@
     "description": "A long stalk covered with fluffy clumps of powdery growth, vaguely resembling cotton bolls.  The resemblance is merely visual, as it simply crumbles into powder if pulled apart.",
     "price": "300 cent",
     "material": [ "mushroom", "powder" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "charges": 4
   },
   {
     "type": "COMESTIBLE",
@@ -74,7 +78,8 @@
     "description": "A stalk of plantlike growth that naturally curls in on itself in a spiral, covered with short, thin leaves.  Every part of the \"plant\" is tough and stringy.",
     "price": "400 cent",
     "material": [ "mushroom", "powder" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "charges": 4
   },
   {
     "type": "COMESTIBLE",
@@ -86,12 +91,13 @@
     "symbol": "/",
     "description": "A woody, tangled branch covered in pods resembling overgrown pecans.  Some of the growths are smaller, softer, and greener in color, but the whole thing seems inedible and useless as-is.",
     "price": "2 USD",
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "charges": 4
   },
   {
     "type": "COMESTIBLE",
     "id": "caveyot_bush_quarry_cooked",
-    "name": { "str": "handful of roasted hardened bramble nuts", "str_pl": "handfuls of roasted hardened bramble nuts" },
+    "name": { "str_sp": "roasted bramble nuts" },
     "looks_like": "hickory_nut_roasted",
     "weight": "120 g",
     "color": "brown",
@@ -99,12 +105,14 @@
     "comestible_type": "FOOD",
     "symbol": "%",
     "quench": -4,
-    "calories": 200,
+    "calories": 400,
     "description": "A handful of pods stripped from a strange branch, roasted in their shells due to how rock-hard they were.  Doing so softened and split open the shells, leaving nuts that seem to have been fried in the pod's own oil.",
     "price": "150 cent",
     "material": [ "mushroom", "nut" ],
     "volume": "125 ml",
+    "charges": 4,
     "flags": [ "EATEN_HOT", "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE" ],
-    "fun": 2
+    "fun": 2,
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 4 ] ]
   }
 ]

--- a/Dorf_Life/modinfo.json
+++ b/Dorf_Life/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Dorf Life",
     "authors": [ "Chaosvolt" ],
     "description": "Adds multi-level caverns hidden away in the underground, breaching the subways to add various strange sights to explore.",
-    "version": "DDA version, update 5/17/2024",
+    "version": "DDA version, update 7/6/2024",
     "category": "buildings",
     "dependencies": [ "dda" ]
   }

--- a/Dorf_Life_BN/cave_terrain.json
+++ b/Dorf_Life_BN/cave_terrain.json
@@ -15,7 +15,7 @@
       {
         "seasons": [ "spring", "summer", "autumn", "winter" ],
         "entries": [
-          { "drop": "caveyot_helmet_plump", "base_num": [ 2, 6 ] },
+          { "drop": "caveyot_helmet_plump", "base_num": [ 1, 2 ] },
           { "drop": "withered", "base_num": [ 0, 1 ] }
         ]
       }
@@ -66,7 +66,7 @@
       {
         "seasons": [ "spring", "summer" ],
         "entries": [
-          { "drop": "caveyot_pod_sweet", "base_num": [ 4, 8 ] },
+          { "drop": "caveyot_pod_sweet", "base_num": [ 1, 3 ] },
           { "drop": "withered", "base_num": [ 1, 3 ] }
         ]
       }
@@ -117,7 +117,7 @@
       {
         "seasons": [ "summer", "autumn" ],
         "entries": [
-          { "drop": "caveyot_wheat_cave", "base_num": [ 4, 8 ] },
+          { "drop": "caveyot_wheat_cave", "base_num": [ 1, 3 ] },
           { "drop": "straw_pile", "base_num": [ 1, 3 ] }
         ]
       }
@@ -168,7 +168,7 @@
       {
         "seasons": [ "summer", "autumn" ],
         "entries": [
-          { "drop": "caveyot_tails_pig", "base_num": [ 4, 8 ] },
+          { "drop": "caveyot_tails_pig", "base_num": [ 1, 3 ] },
           { "drop": "plant_fibre", "base_num": [ 1, 4 ] }
         ]
       }
@@ -219,7 +219,7 @@
       {
         "seasons": [ "spring", "summer", "autumn", "winter" ],
         "entries": [
-          { "drop": "caveyot_bush_quarry", "base_num": [ 4, 8 ] },
+          { "drop": "caveyot_bush_quarry", "base_num": [ 1, 3 ] },
           { "drop": "stick", "base_num": [ 2, 3 ] },
           { "drop": "stick_long", "base_num": [ 1, 2 ] },
           { "drop": "log", "base_num": [ 0, 2 ] }

--- a/Dorf_Life_BN/items.json
+++ b/Dorf_Life_BN/items.json
@@ -158,7 +158,7 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "hardened bramble spores" },
     "description": "Some hardened bramble spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
-    "seed_data": { "plant_name": "hardened bramble", "fruit": "caveyot_bush_quarry", "byproducts": [ "withered" ], "grow": "14 days" },
+    "seed_data": { "plant_name": "hardened bramble", "fruit": "caveyot_bush_quarry", "byproducts": [ "stick" ], "grow": "14 days" },
     "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
   }
 ]

--- a/Dorf_Life_BN/items.json
+++ b/Dorf_Life_BN/items.json
@@ -16,7 +16,9 @@
     "material": "mushroom",
     "volume": "250 ml",
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ],
-    "fun": -1
+    "fun": -1,
+    "charges": 4,
+    "vitamins": [ [ "vitC", 4 ], [ "iron", 7 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -48,7 +50,8 @@
     "description": "A bright red bulb resembling an onion, far more scarlet than the purple of any earthly red onion.  Though it gives off a sweet aroma, its layers are tough and difficult to peel, making it inedible as-is.",
     "price": "150 cent",
     "material": [ "mushroom", "wood" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "charges": 4
   },
   {
     "type": "COMESTIBLE",
@@ -61,7 +64,8 @@
     "description": "A long stalk covered with fluffy clumps of powdery growth, vaguely resembling cotton bolls.  The resemblance is merely visual, as it simply crumbles into powder if pulled apart.",
     "price": "300 cent",
     "material": [ "mushroom", "powder" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "charges": 4
   },
   {
     "type": "COMESTIBLE",
@@ -74,7 +78,8 @@
     "description": "A stalk of plantlike growth that naturally curls in on itself in a spiral, covered with short, thin leaves.  Every part of the \"plant\" is tough and stringy.",
     "price": "400 cent",
     "material": [ "mushroom", "powder" ],
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "charges": 4
   },
   {
     "type": "COMESTIBLE",
@@ -87,12 +92,13 @@
     "description": "A woody, tangled branch covered in pods resembling overgrown pecans.  Some of the growths are smaller, softer, and greener in color, but the whole thing seems inedible and useless as-is.",
     "price": "2 USD",
     "material": "wood",
-    "volume": "250 ml"
+    "volume": "250 ml",
+    "charges": 4
   },
   {
     "type": "COMESTIBLE",
     "id": "caveyot_bush_quarry_cooked",
-    "name": { "str": "handful of roasted hardened bramble nuts", "str_pl": "handfuls of roasted hardened bramble nuts" },
+    "name": { "str_sp": "roasted bramble nuts" },
     "looks_like": "hickory_nut_roasted",
     "weight": "120 g",
     "color": "brown",
@@ -100,13 +106,59 @@
     "comestible_type": "FOOD",
     "symbol": "%",
     "quench": -4,
-    "calories": 200,
+    "calories": 400,
     "description": "A handful of pods stripped from a strange branch, roasted in their shells due to how rock-hard they were.  Doing so softened and split open the shells, leaving nuts that seem to have been fried in the pod's own oil.",
     "price": "150 cent",
     "material": [ "mushroom", "nut" ],
     "volume": "250 ml",
-    "charges": 2,
+    "charges": 4,
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ],
-    "fun": 2
+    "fun": 2,
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 4 ] ]
+  },
+  {
+    "id": "seed_caveyot_helmet_plump",
+    "copy-from": "seed",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "dark truffle spores" },
+    "description": "Some dark truffle spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
+    "seed_data": { "plant_name": "dark truffle", "fruit": "caveyot_helmet_plump", "byproducts": [ "withered" ], "grow": "14 days" },
+    "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
+  },
+  {
+    "id": "seed_caveyot_pod_sweet",
+    "copy-from": "seed",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "vibrant bulb spores" },
+    "description": "Some vibrant bulb spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
+    "seed_data": { "plant_name": "vibrant bulb", "fruit": "caveyot_pod_sweet", "byproducts": [ "withered" ], "grow": "14 days" },
+    "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
+  },
+  {
+    "id": "seed_caveyot_wheat_cave",
+    "copy-from": "seed",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "cloudy brush spores" },
+    "description": "Some cloudy brush spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
+    "seed_data": { "plant_name": "cloudy brush", "fruit": "caveyot_wheat_cave", "byproducts": [ "straw_pile" ], "grow": "14 days" },
+    "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
+  },
+  {
+    "id": "seed_caveyot_tails_pig",
+    "copy-from": "seed",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "spiral stalk spores" },
+    "description": "Some spiral stalk spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
+    "seed_data": { "plant_name": "spiral stalk", "fruit": "caveyot_tails_pig", "byproducts": [ "withered" ], "grow": "14 days" },
+    "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
+  },
+  {
+    "id": "seed_caveyot_bush_quarry",
+    "copy-from": "seed",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "hardened bramble spores" },
+    "description": "Some hardened bramble spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
+    "seed_data": { "plant_name": "hardened bramble", "fruit": "caveyot_bush_quarry", "byproducts": [ "withered" ], "grow": "14 days" },
+    "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
   }
 ]

--- a/Dorf_Life_BN/items.json
+++ b/Dorf_Life_BN/items.json
@@ -122,7 +122,7 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "dark truffle spores" },
     "description": "Some dark truffle spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
-    "seed_data": { "plant_name": "dark truffle", "fruit": "caveyot_helmet_plump", "byproducts": [ "withered" ], "grow": "14 days" },
+    "seed_data": { "plant_name": "dark truffle", "fruit": "caveyot_helmet_plump", "byproducts": [ "withered" ], "required_terrain_flag": "MUSHROOM_PLANTABLE", "grow": "14 days" },
     "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
   },
   {
@@ -131,7 +131,7 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "vibrant bulb spores" },
     "description": "Some vibrant bulb spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
-    "seed_data": { "plant_name": "vibrant bulb", "fruit": "caveyot_pod_sweet", "byproducts": [ "withered" ], "grow": "14 days" },
+    "seed_data": { "plant_name": "vibrant bulb", "fruit": "caveyot_pod_sweet", "byproducts": [ "withered" ], "required_terrain_flag": "MUSHROOM_PLANTABLE", "grow": "14 days" },
     "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
   },
   {
@@ -140,7 +140,7 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "cloudy brush spores" },
     "description": "Some cloudy brush spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
-    "seed_data": { "plant_name": "cloudy brush", "fruit": "caveyot_wheat_cave", "byproducts": [ "straw_pile" ], "grow": "14 days" },
+    "seed_data": { "plant_name": "cloudy brush", "fruit": "caveyot_wheat_cave", "byproducts": [ "straw_pile" ], "required_terrain_flag": "MUSHROOM_PLANTABLE", "grow": "14 days" },
     "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
   },
   {
@@ -149,7 +149,7 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "spiral stalk spores" },
     "description": "Some spiral stalk spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
-    "seed_data": { "plant_name": "spiral stalk", "fruit": "caveyot_tails_pig", "byproducts": [ "withered" ], "grow": "14 days" },
+    "seed_data": { "plant_name": "spiral stalk", "fruit": "caveyot_tails_pig", "byproducts": [ "withered" ], "required_terrain_flag": "MUSHROOM_PLANTABLE", "grow": "14 days" },
     "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
   },
   {
@@ -158,7 +158,7 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "hardened bramble spores" },
     "description": "Some hardened bramble spores.  You could probably \"plant\" this, but it would require tree trunks or dedicated mushroom racks for it to grow.",
-    "seed_data": { "plant_name": "hardened bramble", "fruit": "caveyot_bush_quarry", "byproducts": [ "stick" ], "grow": "14 days" },
+    "seed_data": { "plant_name": "hardened bramble", "fruit": "caveyot_bush_quarry", "byproducts": [ "stick" ], "required_terrain_flag": "MUSHROOM_PLANTABLE", "grow": "14 days" },
     "extend": { "flags": [ "CAN_PLANT_UNDERGROUND" ] }
   }
 ]

--- a/Dorf_Life_BN/modinfo.json
+++ b/Dorf_Life_BN/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Dorf Life",
     "authors": [ "Chaosvolt" ],
     "description": "Adds multi-level caverns hidden away in the underground, breaching the subways to add various strange sights to explore.",
-    "version": "BN version, update 8/3/2023",
+    "version": "BN version, update 7/6/2024",
     "category": "buildings",
     "dependencies": [ "bn" ]
   }

--- a/Dorf_Life_BN/recipes.json
+++ b/Dorf_Life_BN/recipes.json
@@ -177,5 +177,70 @@
       [ [ "rag", -1 ] ]
     ],
     "components": [ [ [ "caveyot_bush_quarry", 1 ] ] ]
+  },
+  {
+    "result": "seed_caveyot_helmet_plump",
+    "type": "recipe",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_SEEDS",
+    "skill_used": "survival",
+    "difficulty": 2,
+    "time": "5 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "caveyot_helmet_plump", 1 ] ] ],
+    "flags": [ "ALLOW_ROTTEN" ]
+  },
+  {
+    "result": "seed_caveyot_pod_sweet",
+    "type": "recipe",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_SEEDS",
+    "skill_used": "survival",
+    "difficulty": 2,
+    "time": "5 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "caveyot_pod_sweet", 1 ] ] ],
+    "flags": [ "ALLOW_ROTTEN" ]
+  },
+  {
+    "result": "seed_caveyot_wheat_cave",
+    "type": "recipe",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_SEEDS",
+    "skill_used": "survival",
+    "difficulty": 2,
+    "time": "5 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "caveyot_wheat_cave", 1 ] ] ],
+    "flags": [ "ALLOW_ROTTEN" ]
+  },
+  {
+    "result": "seed_caveyot_tails_pig",
+    "type": "recipe",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_SEEDS",
+    "skill_used": "survival",
+    "difficulty": 2,
+    "time": "5 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "caveyot_tails_pig", 1 ] ] ],
+    "flags": [ "ALLOW_ROTTEN" ]
+  },
+  {
+    "result": "seed_caveyot_bush_quarry",
+    "type": "recipe",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_SEEDS",
+    "skill_used": "survival",
+    "difficulty": 3,
+    "time": "10 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
+    "components": [ [ [ "caveyot_bush_quarry", 1 ] ] ],
+    "flags": [ "ALLOW_ROTTEN" ]
   }
 ]


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/4937 is merged. In addition to some tweaks to balance for the comestibles themselves, this also adds seeds (well, spores) you can craft to plant in the BN version, requiring a mushroom rack in exchange for requiring mushroom racks to grow on.