### PR TITLE
Pending BN Update: `INDOORS` terrain flag removal

### DIFF
--- a/Dorf_Life/cave_terrain.json
+++ b/Dorf_Life/cave_terrain.json
@@ -11,12 +11,7 @@
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT" ],
     "transforms_into": "t_shrub_helmet_plump_harvested",
     "examine_action": "harvest_ter",
-    "harvest_by_season": [
-      {
-        "seasons": [ "spring", "summer", "autumn", "winter" ],
-        "id": "helmet_plump_harv"
-      }
-    ],
+    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn", "winter" ], "id": "helmet_plump_harv" } ],
     "bash": {
       "str_min": 4,
       "str_max": 60,
@@ -59,12 +54,7 @@
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT" ],
     "transforms_into": "t_shrub_pod_sweet_harvested",
     "examine_action": "harvest_ter",
-    "harvest_by_season": [
-      {
-        "seasons": [ "spring", "summer" ],
-        "id": "pod_sweet_harv"
-      }
-    ],
+    "harvest_by_season": [ { "seasons": [ "spring", "summer" ], "id": "pod_sweet_harv" } ],
     "bash": {
       "str_min": 4,
       "str_max": 60,
@@ -107,12 +97,7 @@
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT" ],
     "transforms_into": "t_shrub_wheat_cave_harvested",
     "examine_action": "harvest_ter",
-    "harvest_by_season": [
-      {
-        "seasons": [ "summer", "autumn" ],
-        "id": "wheat_cave_harv"
-      }
-    ],
+    "harvest_by_season": [ { "seasons": [ "summer", "autumn" ], "id": "wheat_cave_harv" } ],
     "bash": {
       "str_min": 4,
       "str_max": 60,
@@ -155,12 +140,7 @@
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT" ],
     "transforms_into": "t_shrub_tails_pig_harvested",
     "examine_action": "harvest_ter",
-    "harvest_by_season": [
-      {
-        "seasons": [ "summer", "autumn" ],
-        "id": "tail_pig_harv"
-      }
-    ],
+    "harvest_by_season": [ { "seasons": [ "summer", "autumn" ], "id": "tail_pig_harv" } ],
     "bash": {
       "str_min": 4,
       "str_max": 60,
@@ -203,12 +183,7 @@
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SHARP" ],
     "transforms_into": "t_shrub_bush_quarry_harvested",
     "examine_action": "harvest_ter",
-    "harvest_by_season": [
-      {
-        "seasons": [ "spring", "summer", "autumn", "winter" ],
-        "id": "bush_quarry_harv"
-      }
-    ],
+    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn", "winter" ], "id": "bush_quarry_harv" } ],
     "bash": {
       "str_min": 4,
       "str_max": 60,
@@ -270,7 +245,7 @@
     "color": "light_gray",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
     "bash": {
       "str_min": 120,
       "str_max": 400,
@@ -289,7 +264,7 @@
     "symbol": "6",
     "color": "cyan_red",
     "move_cost": 0,
-    "flags": [ "NOITEM", "INDOORS", "PERMEABLE" ],
+    "flags": [ "NOITEM", "PERMEABLE" ],
     "examine_action": "controls_gate"
   },
   {
@@ -322,7 +297,7 @@
     "symbol": ".",
     "color": "cyan",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "FLAT", "ROAD" ],
     "close": "t_breach_concrete_fake_c",
     "bash": {
       "str_min": 120,

--- a/Dorf_Life_BN/cave_terrain.json
+++ b/Dorf_Life_BN/cave_terrain.json
@@ -14,7 +14,10 @@
     "harvest_by_season": [
       {
         "seasons": [ "spring", "summer", "autumn", "winter" ],
-        "entries": [ { "drop": "caveyot_helmet_plump", "base_num": [ 1, 2 ] }, { "drop": "withered", "base_num": [ 0, 1 ], "no_auto_pickup": true } ]
+        "entries": [
+          { "drop": "caveyot_helmet_plump", "base_num": [ 1, 2 ] },
+          { "drop": "withered", "base_num": [ 0, 1 ], "no_auto_pickup": true }
+        ]
       }
     ],
     "bash": {
@@ -62,7 +65,10 @@
     "harvest_by_season": [
       {
         "seasons": [ "spring", "summer" ],
-        "entries": [ { "drop": "caveyot_pod_sweet", "base_num": [ 1, 3 ] }, { "drop": "withered", "base_num": [ 1, 3 ], "no_auto_pickup": true } ]
+        "entries": [
+          { "drop": "caveyot_pod_sweet", "base_num": [ 1, 3 ] },
+          { "drop": "withered", "base_num": [ 1, 3 ], "no_auto_pickup": true }
+        ]
       }
     ],
     "bash": {
@@ -110,7 +116,10 @@
     "harvest_by_season": [
       {
         "seasons": [ "summer", "autumn" ],
-        "entries": [ { "drop": "caveyot_wheat_cave", "base_num": [ 1, 3 ] }, { "drop": "straw_pile", "base_num": [ 1, 3 ], "no_auto_pickup": true } ]
+        "entries": [
+          { "drop": "caveyot_wheat_cave", "base_num": [ 1, 3 ] },
+          { "drop": "straw_pile", "base_num": [ 1, 3 ], "no_auto_pickup": true }
+        ]
       }
     ],
     "bash": {
@@ -158,7 +167,10 @@
     "harvest_by_season": [
       {
         "seasons": [ "summer", "autumn" ],
-        "entries": [ { "drop": "caveyot_tails_pig", "base_num": [ 1, 3 ] }, { "drop": "plant_fibre", "base_num": [ 1, 4 ], "no_auto_pickup": true } ]
+        "entries": [
+          { "drop": "caveyot_tails_pig", "base_num": [ 1, 3 ] },
+          { "drop": "plant_fibre", "base_num": [ 1, 4 ], "no_auto_pickup": true }
+        ]
       }
     ],
     "bash": {
@@ -277,7 +289,7 @@
     "color": "light_gray",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
     "bash": {
       "str_min": 120,
       "str_max": 400,
@@ -296,7 +308,7 @@
     "symbol": "6",
     "color": "cyan_red",
     "move_cost": 0,
-    "flags": [ "NOITEM", "INDOORS", "PERMEABLE" ],
+    "flags": [ "NOITEM", "PERMEABLE" ],
     "examine_action": "controls_gate"
   },
   {
@@ -331,7 +343,7 @@
     "symbol": ".",
     "color": "cyan",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "FLAT", "ROAD" ],
     "close": "t_breach_concrete_fake_c",
     "bash": {
       "str_min": 120,

--- a/Dorf_Life_BN/modinfo.json
+++ b/Dorf_Life_BN/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Dorf Life",
     "authors": [ "Chaosvolt" ],
     "description": "Adds multi-level caverns hidden away in the underground, breaching the subways to add various strange sights to explore.",
-    "version": "BN version, update 10/30/2024",
+    "version": "BN version, update 4/18/2026",
     "category": "buildings",
     "dependencies": [ "bn" ]
   }

--- a/Dorf_Life_BN/obsolete.json
+++ b/Dorf_Life_BN/obsolete.json
@@ -9,7 +9,7 @@
     "color": "cyan",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "INDOORS", "FLAT" ],
+    "flags": [ "TRANSPARENT", "FLAT" ],
     "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   }
 ]


### PR DESCRIPTION
Set aside for when https://github.com/cataclysmbn/Cataclysm-BN/pull/8542 is merged, removing use of the now unused `INDOORS` flag.